### PR TITLE
`BaseSpider`: add `dont_filter` flag to player redirects

### DIFF
--- a/myfirstproject/myfirstproject/spiders/al_central_metadata.py
+++ b/myfirstproject/myfirstproject/spiders/al_central_metadata.py
@@ -3,9 +3,9 @@ from .base_spider import BaseSpider
 class ALCentralSpider(BaseSpider):
     name = 'al_central_meta'
     start_urls = (
-        [f'https://www.baseball-reference.com/teams/CLE/2023-roster.shtml'] +
-        [f'https://www.baseball-reference.com/teams/MIN/2023-roster.shtml'] +
-        [f'https://www.baseball-reference.com/teams/DET/2023-roster.shtml'] +
-        [f'https://www.baseball-reference.com/teams/CHW/2023-roster.shtml'] +
-        [f'https://www.baseball-reference.com/teams/KCR/2023-roster.shtml']
+        [f'https://www.baseball-reference.com/teams/CLE/{year}-roster.shtml' for year in range(2003, 2024)] +
+        [f'https://www.baseball-reference.com/teams/MIN/{year}-roster.shtml' for year in range(2003, 2024)] +
+        [f'https://www.baseball-reference.com/teams/DET/{year}-roster.shtml' for year in range(2003, 2024)] +
+        [f'https://www.baseball-reference.com/teams/CHW/{year}-roster.shtml' for year in range(2003, 2024)] +
+        [f'https://www.baseball-reference.com/teams/KCR/{year}-roster.shtml' for year in range(2003, 2024)]
     )

--- a/myfirstproject/myfirstproject/spiders/al_east_metadata.py
+++ b/myfirstproject/myfirstproject/spiders/al_east_metadata.py
@@ -1,0 +1,13 @@
+from .base_spider import BaseSpider
+
+class ALCentralSpider(BaseSpider):
+    name = 'al_east_meta'
+    start_urls = (
+        [f'https://www.baseball-reference.com/teams/NYY/{year}-roster.shtml' for year in range(2003, 2024)] +
+        [f'https://www.baseball-reference.com/teams/BOS/{year}-roster.shtml' for year in range(2003, 2024)] +
+        # 2003-2007: "Tampa Bay Devil Rays", 2008-Present: "Tampa Bay Rays"
+        [f'https://www.baseball-reference.com/teams/TBD/{year}-roster.shtml' for year in range(2003, 2008)] +
+        [f'https://www.baseball-reference.com/teams/TBR/{year}-roster.shtml' for year in range(2008, 2024)] +
+        [f'https://www.baseball-reference.com/teams/TOR/{year}-roster.shtml' for year in range(2003, 2024)] +
+        [f'https://www.baseball-reference.com/teams/BAL/{year}-roster.shtml' for year in range(2003, 2024)]
+    )

--- a/myfirstproject/myfirstproject/spiders/al_east_metadata.py
+++ b/myfirstproject/myfirstproject/spiders/al_east_metadata.py
@@ -1,6 +1,6 @@
 from .base_spider import BaseSpider
 
-class ALCentralSpider(BaseSpider):
+class ALEastSpider(BaseSpider):
     name = 'al_east_meta'
     start_urls = (
         [f'https://www.baseball-reference.com/teams/NYY/{year}-roster.shtml' for year in range(2003, 2024)] +

--- a/myfirstproject/myfirstproject/spiders/al_west_metadata.py
+++ b/myfirstproject/myfirstproject/spiders/al_west_metadata.py
@@ -1,0 +1,13 @@
+from .base_spider import BaseSpider
+
+class ALCentralSpider(BaseSpider):
+    name = 'al_west_meta'
+    start_urls = (
+        [f'https://www.baseball-reference.com/teams/OAK/{year}-roster.shtml' for year in range(2003, 2024)] +
+        [f'https://www.baseball-reference.com/teams/HOU/{year}-roster.shtml' for year in range(2003, 2024)] +
+        # 2003-2004: "California Angels", 2005-Present: "Los Angeles Angels of Anaheim"
+        [f'https://www.baseball-reference.com/teams/CAL/{year}-roster.shtml' for year in range(2003, 2005)] +
+        [f'https://www.baseball-reference.com/teams/LAA/{year}-roster.shtml' for year in range(2005, 2024)] +
+        [f'https://www.baseball-reference.com/teams/SEA/{year}-roster.shtml' for year in range(2003, 2024)] +
+        [f'https://www.baseball-reference.com/teams/TEX/{year}-roster.shtml' for year in range(2003, 2024)]
+    )

--- a/myfirstproject/myfirstproject/spiders/al_west_metadata.py
+++ b/myfirstproject/myfirstproject/spiders/al_west_metadata.py
@@ -1,6 +1,6 @@
 from .base_spider import BaseSpider
 
-class ALCentralSpider(BaseSpider):
+class ALWestSpider(BaseSpider):
     name = 'al_west_meta'
     start_urls = (
         [f'https://www.baseball-reference.com/teams/OAK/{year}-roster.shtml' for year in range(2003, 2024)] +

--- a/myfirstproject/myfirstproject/spiders/base_spider.py
+++ b/myfirstproject/myfirstproject/spiders/base_spider.py
@@ -47,7 +47,8 @@ class BaseSpider(scrapy.Spider):
                                     'player': player,
                                     'isPitcher': num_games_pitched != "0",
                                     'year': year,
-                                 })
+                                 },
+                                 dont_filter = True)
 
     def parse_individual_stats(self, response, player, isPitcher, year):
         # add the is_pitcher attr to the payload before anything else
@@ -126,7 +127,8 @@ class BaseSpider(scrapy.Spider):
             yield scrapy.Request(
                 response.urljoin(player_info_link),
                 callback=self.parse_player_info,
-                cb_kwargs={'player': player}
+                cb_kwargs={'player': player},
+                dont_filter = True
             )
         else:
             # if the link does not exist, just yield the player info we already have

--- a/myfirstproject/myfirstproject/spiders/nl_central_metadata.py
+++ b/myfirstproject/myfirstproject/spiders/nl_central_metadata.py
@@ -3,9 +3,9 @@ from .base_spider import BaseSpider
 class NLCentralSpider(BaseSpider):
     name = 'nl_central_meta'
     start_urls = (
-        [f'https://www.baseball-reference.com/teams/MIL/{year}-roster.shtml' for year in range(1970, 2024)] +
-        [f'https://www.baseball-reference.com/teams/CIN/{year}-roster.shtml' for year in range(1887, 2024)] +
-        [f'https://www.baseball-reference.com/teams/CHC/{year}-roster.shtml' for year in range(1904, 2024)] +
-        [f'https://www.baseball-reference.com/teams/PIT/{year}-roster.shtml' for year in range(1895, 2024)] +
-        [f'https://www.baseball-reference.com/teams/STL/{year}-roster.shtml' for year in range(1900, 2024)]
+        [f'https://www.baseball-reference.com/teams/MIL/{year}-roster.shtml' for year in range(2003, 2024)] +
+        [f'https://www.baseball-reference.com/teams/CIN/{year}-roster.shtml' for year in range(2003, 2024)] +
+        [f'https://www.baseball-reference.com/teams/CHC/{year}-roster.shtml' for year in range(2003, 2024)] +
+        [f'https://www.baseball-reference.com/teams/PIT/{year}-roster.shtml' for year in range(2003, 2024)] +
+        [f'https://www.baseball-reference.com/teams/STL/{year}-roster.shtml' for year in range(2003, 2024)]
     )

--- a/myfirstproject/myfirstproject/spiders/nl_east_metadata.py
+++ b/myfirstproject/myfirstproject/spiders/nl_east_metadata.py
@@ -3,9 +3,13 @@ from .base_spider import BaseSpider
 class NLEastSpider(BaseSpider):
     name = 'nl_east_meta'
     start_urls = (
-        [f'https://www.baseball-reference.com/teams/NYM/{year}-roster.shtml' for year in range(1962, 2024)] +
-        [f'https://www.baseball-reference.com/teams/MIA/{year}-roster.shtml' for year in range(2012, 2024)] +
-        [f'https://www.baseball-reference.com/teams/PHI/{year}-roster.shtml' for year in range(1886, 2024)] +
-        [f'https://www.baseball-reference.com/teams/ATL/{year}-roster.shtml' for year in range(1966, 2024)] +
+        [f'https://www.baseball-reference.com/teams/NYM/{year}-roster.shtml' for year in range(2003, 2024)] +
+        # 2003-2011: "Florida Marlins", 2012-Present: "Miami Marlins"
+        [f'https://www.baseball-reference.com/teams/FLA/{year}-roster.shtml' for year in range(2003, 2012)] +
+        [f'https://www.baseball-reference.com/teams/MIA/{year}-roster.shtml' for year in range(2012, 2024)]
+        [f'https://www.baseball-reference.com/teams/PHI/{year}-roster.shtml' for year in range(2003, 2024)] +
+        [f'https://www.baseball-reference.com/teams/ATL/{year}-roster.shtml' for year in range(2003, 2024)] +
+        # # 2003-2004: "Montreal Expos", 2005-Present: "Washington Nationals"
+        [f'https://www.baseball-reference.com/teams/MON/{year}-roster.shtml' for year in range(2003, 2005)] +
         [f'https://www.baseball-reference.com/teams/WSN/{year}-roster.shtml' for year in range(2005, 2024)]
     )

--- a/myfirstproject/myfirstproject/spiders/nl_west_metadata.py
+++ b/myfirstproject/myfirstproject/spiders/nl_west_metadata.py
@@ -3,9 +3,9 @@ from .base_spider import BaseSpider
 class NLWestSpider(BaseSpider):
     name = 'nl_west_meta'
     start_urls = (
-        [f'https://www.baseball-reference.com/teams/SFG/{year}-roster.shtml' for year in range(1958, 2024)] +
-        [f'https://www.baseball-reference.com/teams/ARI/{year}-roster.shtml' for year in range(1998, 2024)] +
-        [f'https://www.baseball-reference.com/teams/COL/{year}-roster.shtml' for year in range(1993, 2024)] +
-        [f'https://www.baseball-reference.com/teams/LAD/{year}-roster.shtml' for year in range(1958, 2024)] +
-        [f'https://www.baseball-reference.com/teams/SDP/{year}-roster.shtml' for year in range(1969, 2024)]
+        [f'https://www.baseball-reference.com/teams/SFG/{year}-roster.shtml' for year in range(2003, 2024)]
+        [f'https://www.baseball-reference.com/teams/ARI/{year}-roster.shtml' for year in range(2003, 2024)] +
+        [f'https://www.baseball-reference.com/teams/COL/{year}-roster.shtml' for year in range(2003, 2024)] +
+        [f'https://www.baseball-reference.com/teams/LAD/{year}-roster.shtml' for year in range(2003, 2024)] +
+        [f'https://www.baseball-reference.com/teams/SDP/{year}-roster.shtml' for year in range(2003, 2024)]
     )


### PR DESCRIPTION
Set `dont_filter` to `True` on player link redirects since we want to retrieve season-specific stats for a given player.

Add JSON output for the San Francisco Giants rosters from 2003 to 2023.