### PR TITLE
README/`BaseSpider`: add additional content, comments

### DIFF
--- a/myfirstproject/README.md
+++ b/myfirstproject/README.md
@@ -23,3 +23,59 @@ running, use the `-L` option:
 ```console
 scrapy crawl posey_stats -L INFO
 ```
+
+---
+
+## MLB Data Spider
+
+The `BaseSpider` class contains all of the scraping/parsing code for our
+project. We are interested in gathering player data from active MLB rosters
+over the course of the 2022 and 2023 MLB seasons. For each player on the active
+roster, we crawl to their home profile page and scrape their statistics from
+the given season.
+
+Since player statistics are different between a pitcher and a position player,
+we need to check for the player's primary position before we search for certain
+statistics. For this, a `isPitcher` parameter of type `bool` is passed in the
+callback for each player's home page. Certain statistics of interest are then
+gathered and placed in the JSON object for each player.
+
+Finally, another crawl is attempted for each player's **Biographical
+Information** section on their Wiki page on Baseball-Reference. If one exists,
+the text of this section is scraped and also placed in a key-value pair in the
+player's JSON object.
+
+A separate spider contains all of the starting links that we are interested in:
+`mlb_2022_2023.py`. This Python file contains the links for every team's 2022
+and 2023 roster, grouped by division.
+
+In summary, the crawling process looks like the following:
+
+1. start from a team's active roster page from 2022 or 2023 page
+2. for each team's active roster page:
+3. gather metadata for player
+4. crawl to each player's home profile page
+5. scrape statistics from 2022 or 2023 page
+6. crawl to player's Wiki page (if one exists)
+7. scrape "Biographical Information" from Wiki page (if one exists)
+
+The spider scrapes about 1.3 GB of data in total and runs in just under seven
+hours. About 6700 GET requests are made and just over 3200 items are stored in
+the resulting JSON file. Below is a breakdown of some interesting statistics
+reported by Scrapy:
+
+```
+2024-01-30 17:35:54 [scrapy.extensions.feedexport] INFO: Stored json feed (3279 items) in: json_data/mlb_data.json
+2024-01-30 17:35:54 [scrapy.statscollectors] INFO: Dumping Scrapy stats:
+{
+    'downloader/request_bytes': 3227315,
+    'downloader/request_count': 6667,
+    'downloader/request_method_count/GET': 6667,
+    'downloader/response_bytes': 273457667,
+    'downloader/response_count': 6667,
+    'elapsed_time_seconds': 24519.853224,
+    'httpcompression/response_bytes': 1492804240,
+    'item_scraped_count': 3279,
+    'request_depth_max': 2,
+}
+```

--- a/myfirstproject/myfirstproject/spiders/base_spider.py
+++ b/myfirstproject/myfirstproject/spiders/base_spider.py
@@ -9,7 +9,7 @@ class BaseSpider(scrapy.Spider):
         # iterate through each row in the roster table
         rows = response.css('#appearances > tbody > tr')
         for row in rows:
-            # get all of the data we are interested in from the parent table
+            # get metadata from the parent table that contains active roster
             name = row.css('th > a::text').get()
             age = row.css('td[data-stat="age"]::text').get()
             height = row.css('td[data-stat="height"]::text').get()
@@ -21,12 +21,14 @@ class BaseSpider(scrapy.Spider):
             war = row.css('td[data-stat="WAR"]::text').get()
             salary = row.css('td[data-stat="Salary"]::text').get()
 
-            # var to determine if player is pitcher or not
+            # var to determine if player is pitcher or not by looking at
+            # number of games they were announced as a pitcher in
             num_games_pitched = row.css('td[data-stat="G_p_app"]::text').get()
             
-            # extract the player link
+            # extract the player's home page link from parent table
             player_link = row.css('th > a::attr(href)').get()
 
+            # begin construction of JSON object to store scraped data
             player = {
                 'year': year,
                 'name': name,


### PR DESCRIPTION
This PR just adds some additional content to the spider's README file concerning what information is scraped by the spider as well as some improved comments in the `BaseSpider` class to add context to what it is doing.